### PR TITLE
Rename all D to γ, add embed

### DIFF
--- a/src/estimate_delay.jl
+++ b/src/estimate_delay.jl
@@ -8,7 +8,7 @@ export estimate_delay
 """
     estimate_delay(s, method::String) -> τ
 
-Estimate an optimal delay to be used in [`reconstruct`](@ref).
+Estimate an optimal delay to be used in [`reconstruct`](@ref) or [`embed`](@ref).
 Return the exponential decay time `τ` rounded to an integer.
 
 The `method` can be one of the following:

--- a/src/estimate_dimension.jl
+++ b/src/estimate_dimension.jl
@@ -14,7 +14,7 @@ temporal neighbors `γ` to be used in [`reconstruct`](@ref) or [`embed`](@ref).
 Given the scalar timeseries `s` and the embedding delay `τ` compute the
 values of `E₁` for each `γ ∈ γs`, according to Cao's Method (eq. 3 of [1]).
 Please be aware that in **DynamicalSystems.jl** `γ` stands for the amount of temporal
-neighbors and not the embedding dimension (`D = γ + 1`, see also [`embed`](@ref).
+neighbors and not the embedding dimension (`D = γ + 1`, see also [`embed`](@ref)).
 
 Return the vector of all computed `E₁`s. To estimate a good value for `γ` from this,
 find `γ` for which the value `E₁` saturates at some value around 1.

--- a/src/estimate_dimension.jl
+++ b/src/estimate_dimension.jl
@@ -5,19 +5,19 @@ export estimate_dimension, stochastic_indicator
 #                                Estimate Dimension                                 #
 #####################################################################################
 """
-    estimate_dimension(s::AbstractVector, τ:Int, Ds = 1:5) -> E₁s
+    estimate_dimension(s::AbstractVector, τ:Int, γs = 1:5) -> E₁s
 
 Compute a quantity that can estimate an optimal amount of
-temporal neighbors `D` to be used in [`reconstruct`](@ref).
+temporal neighbors `γ` to be used in [`reconstruct`](@ref) or [`embed`](@ref).
 
 ## Description
 Given the scalar timeseries `s` and the embedding delay `τ` compute the
-values of `E₁` for each `D ∈ Ds`, according to Cao's Method (eq. 3 of [1]).
-Please be aware that in **DynamicalSystems.jl** `D` stands for the amount of temporal
-neighbors, *not* the dimension as in [1]. The dimension is `D+1`.
+values of `E₁` for each `γ ∈ γs`, according to Cao's Method (eq. 3 of [1]).
+Please be aware that in **DynamicalSystems.jl** `γ` stands for the amount of temporal
+neighbors and not the embedding dimension (`D = γ + 1`, see also [`embed`](@ref).
 
-Return the vector of all computed `E₁`s. To estimate a good value for `D` from this,
-find `D` for which the value `E₁` saturates at some value around 1.
+Return the vector of all computed `E₁`s. To estimate a good value for `γ` from this,
+find `γ` for which the value `E₁` saturates at some value around 1.
 
 *Note: This method does not work for datasets with perfectly periodic signals.*
 
@@ -25,23 +25,23 @@ find `D` for which the value `E₁` saturates at some value around 1.
 
 [1] : Liangyue Cao, [Physica D, pp. 43-50 (1997)](https://www.sciencedirect.com/science/article/pii/S0167278997001188?via%3Dihub)
 """
-function estimate_dimension(s::AbstractVector{T}, τ::Int, Ds = 1:5) where {T}
-    E1s = zeros(T, length(Ds))
+function estimate_dimension(s::AbstractVector{T}, τ::Int, γs = 1:5) where {T}
+    E1s = zeros(T, length(γs))
     aafter = zero(T)
-    aprev = _average_a(s, Ds[1], τ)
-    for (i, D) ∈ enumerate(Ds)
-        aafter = _average_a(s, D+1, τ)
+    aprev = _average_a(s, γs[1], τ)
+    for (i, γ) ∈ enumerate(γs)
+        aafter = _average_a(s, γ+1, τ)
         E1s[i] = aafter/aprev
         aprev = aafter
     end
     return E1s
 end
-# then use function `saturation_point(Ds, E1s)` from ChaosTools
+# then use function `saturation_point(γs, E1s)` from ChaosTools
 
-function _average_a(s::AbstractVector{T},D,τ) where T
+function _average_a(s::AbstractVector{T},γ,τ) where T
     #Sum over all a(i,d) of the Ddim Reconstructed space, equation (2)
-    R1 = reconstruct(s,D+1,τ)
-    R2 = reconstruct(s[1:end-τ],D,τ)
+    R1 = reconstruct(s,γ+1,τ)
+    R2 = reconstruct(s[1:end-τ],γ,τ)
     tree2 = KDTree(R2)
     nind = (x = knn(tree2, R2.data, 2)[1]; [ind[1] for ind in x])
     e=0.
@@ -57,36 +57,36 @@ function _average_a(s::AbstractVector{T},D,τ) where T
     return e / length(R1)
 end
 
-function dimension_indicator(s,D,τ) #this is E1, equation (3) of Cao
-    return _average_a(s,D+1,τ)/_average_a(s,D,τ)
+function dimension_indicator(s,γ,τ) #this is E1, equation (3) of Cao
+    return _average_a(s,γ+1,τ)/_average_a(s,γ,τ)
 end
 
 
 """
-    stochastic_indicator(s::AbstractVector, τ:Int, Ds = 1:4) -> E₂s
+    stochastic_indicator(s::AbstractVector, τ:Int, γs = 1:4) -> E₂s
 
-Compute an estimator for apparent randomness in a reconstruction with `Ds` temporal
+Compute an estimator for apparent randomness in a reconstruction with `γs` temporal
 neighbors.
 
 ## Description
 Given the scalar timeseries `s` and the embedding delay `τ` compute the
-values of `E₂` for each `D ∈ Ds`, according to Cao's Method (eq. 5 of [1]).
+values of `E₂` for each `γ ∈ γs`, according to Cao's Method (eq. 5 of [1]).
 
 Use this function to confirm that the
 input signal is not random and validate the results of [`estimate_dimension`](@ref).
-In the case of random signals, it should be `E₂ ≈ 1 ∀ D`.
+In the case of random signals, it should be `E₂ ≈ 1 ∀ γ`.
 
 ## References
 
 [1] : Liangyue Cao, [Physica D, pp. 43-50 (1997)](https://www.sciencedirect.com/science/article/pii/S0167278997001188?via%3Dihub)
 """
-function stochastic_indicator(s::AbstractVector{T},τ, Ds=1:4) where T # E2, equation (5)
+function stochastic_indicator(s::AbstractVector{T},τ, γs=1:4) where T # E2, equation (5)
     #This function tries to tell the difference between deterministic
     #and stochastic signals
-    #Calculate E* for Dimension D+1
+    #Calculate E* for Dimension γ+1
     E2s = Float64[]
-    for D ∈ Ds
-        R1 = reconstruct(s,D+1,τ)
+    for γ ∈ γs
+        R1 = reconstruct(s,γ+1,τ)
         tree1 = KDTree(R1[1:end-1-τ])
         method = FixedMassNeighborhood(2)
 
@@ -96,8 +96,8 @@ function stochastic_indicator(s::AbstractVector{T},τ, Ds=1:4) where T # E2, equ
             Es1 += abs(R1[i+τ][end] - R1[j+τ][end]) / length(R1)
         end
 
-        #Calculate E* for Dimension D
-        R2 = reconstruct(s,D,τ)
+        #Calculate E* for Dimension γ
+        R2 = reconstruct(s,γ,τ)
         tree2 = KDTree(R2[1:end-1-τ])
         Es2 = 0.
         nind = (x = neighborhood(R2[1:end-τ], tree2, method); [ind[1] for ind in x])

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -13,65 +13,68 @@ methods.
 abstract type AbstractEmbedding <: Function end
 
 """
-    DelayEmbedding(D, τ) -> `embedding`
+    DelayEmbedding(γ, τ) -> `embedding`
 Return a delay coordinates embedding structure to be used as a functor,
 given a timeseries and some index. Calling
 ```julia
 embedding(s, n)
 ```
-will create the `n`-th reconstructed vector of the embedded space, which has `D`
+will create the `n`-th reconstructed vector of the embedded space, which has `γ`
 temporal neighbors with delay(s) `τ`. See [`reconstruct`](@ref) for more.
 
 *Be very careful when choosing `n`, because `@inbounds` is used internally.*
 """
-struct DelayEmbedding{D} <: AbstractEmbedding
-    delays::SVector{D, Int}
+struct DelayEmbedding{γ} <: AbstractEmbedding
+    delays::SVector{γ, Int}
 end
 
-@inline DelayEmbedding(D, τ) = DelayEmbedding(Val{D}(), τ)
-@inline function DelayEmbedding(::Val{D}, τ::Int) where {D}
-    idxs = [k*τ for k in 1:D]
-    return DelayEmbedding{D}(SVector{D, Int}(idxs...))
+@inline DelayEmbedding(γ, τ) = DelayEmbedding(Val{γ}(), τ)
+@inline function DelayEmbedding(::Val{γ}, τ::Int) where {γ}
+    idxs = [k*τ for k in 1:γ]
+    return DelayEmbedding{γ}(SVector{γ, Int}(idxs...))
 end
-@inline function DelayEmbedding(::Val{D}, τ::AbstractVector) where {D}
-    D != length(τ) && throw(ArgumentError(
+@inline function DelayEmbedding(::Val{γ}, τ::AbstractVector) where {γ}
+    γ != length(τ) && throw(ArgumentError(
     "Delay time vector length must equal the number of temporal neighbors."
     ))
-    return DelayEmbedding{D}(SVector{D, Int}(τ...))
+    return DelayEmbedding{γ}(SVector{γ, Int}(τ...))
 end
 
-@generated function (r::DelayEmbedding{D})(s::AbstractArray{T}, i) where {D, T}
-    gens = [:(s[i + r.delays[$k]]) for k=1:D]
+@generated function (r::DelayEmbedding{γ})(s::AbstractArray{T}, i) where {γ, T}
+    gens = [:(s[i + r.delays[$k]]) for k=1:γ]
     quote
         @_inline_meta
-        @inbounds return SVector{$D+1,T}(s[i], $(gens...))
+        @inbounds return SVector{$γ+1,T}(s[i], $(gens...))
     end
 end
 
 """
-    reconstruct(s, D, τ)
-Reconstruct `s` using the delay coordinates embedding with `D` temporal neighbors
+    reconstruct(s, γ, τ)
+Reconstruct `s` using the delay coordinates embedding with `γ` temporal neighbors
 and delay `τ` and return the result as a [`Dataset`](@ref).
+
+See [`embed`](@ref) for the version that accepts the embedding dimension `D = γ+1`
+directly.
 
 ## Description
 ### Single Timeseries
 If `τ` is an integer, then the ``n``-th entry of the embedded space is
 ```math
-(s(n), s(n+\\tau), s(n+2\\tau), \\dots, s(n+D\\tau))
+(s(n), s(n+\\tau), s(n+2\\tau), \\dots, s(n+γ\\tau))
 ```
-If instead `τ` is a vector of integers, so that `length(τ) == D`,
+If instead `τ` is a vector of integers, so that `length(τ) == γ`,
 then the ``n``-th entry is
 ```math
-(s(n), s(n+\\tau[1]), s(n+\\tau[2]), \\dots, s(n+\\tau[D]))
+(s(n), s(n+\\tau[1]), s(n+\\tau[2]), \\dots, s(n+\\tau[γ]))
 ```
 
 The reconstructed dataset can have same
 invariant quantities (like e.g. lyapunov exponents) with the original system
-that the timeseries were recorded from, for proper `D` and `τ` [1, 2].
+that the timeseries were recorded from, for proper `γ` and `τ` [1, 2].
 The case of different delay times allows reconstructing systems with many time scales,
 see [3].
 
-*Notice* - The dimension of the returned dataset is `D+1`!
+*Notice* - The dimension of the returned dataset is `γ+1`!
 
 ### Multiple Timeseries
 To make a reconstruction out of a multiple timeseries (i.e. trajectory) the number
@@ -83,15 +86,15 @@ of timeseries must be known by type, so `s` can be either:
 If the trajectory is for example ``(x, y)`` and `τ` is integer, then the ``n``-th
 entry of the embedded space is
 ```math
-(x(n), y(n), x(n+\\tau), y(n+\\tau), \\dots, x(n+D\\tau), y(n+D\\tau))
+(x(n), y(n), x(n+\\tau), y(n+\\tau), \\dots, x(n+γ\\tau), y(n+γ\\tau))
 ```
-If `τ` is an `AbstractMatrix{Int}`, so that `size(τ) == (D, B)`,
+If `τ` is an `AbstractMatrix{Int}`, so that `size(τ) == (γ, B)`,
 then we have
 ```math
-(x(n), y(n), x(n+\\tau[1, 1]), y(n+\\tau[1, 2]), \\dots, x(n+\\tau[D, 1]), y(n+\\tau[D, 2]))
+(x(n), y(n), x(n+\\tau[1, 1]), y(n+\\tau[1, 2]), \\dots, x(n+\\tau[γ, 1]), y(n+\\tau[γ, 2]))
 ```
 
-*Notice* - The dimension of the returned dataset is `(D+1)*B`!
+*Notice* - The dimension of the returned dataset is `(γ+1)*B`!
 
 ## References
 [1] : F. Takens, *Detecting Strange Attractors in Turbulence — Dynamical
@@ -101,24 +104,24 @@ Systems and Turbulence*, Lecture Notes in Mathematics **366**, Springer (1981)
 
 [3] : K. Judd & A. Mees, [Physica D **120**, pp 273 (1998)](https://www.sciencedirect.com/science/article/pii/S0167278997001188)
 """
-@inline function reconstruct(s::AbstractVector{T}, D, τ) where {T}
-    de::DelayEmbedding{D} = DelayEmbedding(Val{D}(), τ)
+function reconstruct(s::AbstractVector{T}, γ, τ) where {T}
+    de::DelayEmbedding{γ} = DelayEmbedding(Val{γ}(), τ)
     return reconstruct(s, de)
 end
-@inline function reconstruct(s::AbstractVector{T}, de::DelayEmbedding{D}) where {T, D}
+@inline function reconstruct(s::AbstractVector{T}, de::DelayEmbedding{γ}) where {T, γ}
     L = length(s) - maximum(de.delays)
-    data = Vector{SVector{D+1, T}}(undef, L)
+    data = Vector{SVector{γ+1, T}}(undef, L)
     @inbounds for i in 1:L
         data[i] = de(s, i)
     end
-    return Dataset{D+1, T}(data)
+    return Dataset{γ+1, T}(data)
 end
 
 #####################################################################################
 #                              MultiDimensional R                                   #
 #####################################################################################
 """
-    MTDelayEmbedding(D, τ, B) -> `embedding`
+    MTDelayEmbedding(γ, τ, B) -> `embedding`
 Return a delay coordinates embedding structure to be used as a functor,
 given multiple timeseries (`B` in total), either as a [`Dataset`](@ref) or a
 `SizedArray` (see [`reconstruct`](@ref)), and some index.
@@ -126,61 +129,61 @@ Calling
 ```julia
 embedding(s, n)
 ```
-will create the `n`-th reconstructed vector of the embedded space, which has `D`
+will create the `n`-th reconstructed vector of the embedded space, which has `γ`
 temporal neighbors with delay(s) `τ`. See [`reconstruct`](@ref) for more.
 
 *Be very careful when choosing `n`, because `@inbounds` is used internally.*
 """
-struct MTDelayEmbedding{D, B, X} <: AbstractEmbedding
-    delays::SMatrix{D, B, Int, X} # X = D*B = total dimension number
+struct MTDelayEmbedding{γ, B, X} <: AbstractEmbedding
+    delays::SMatrix{γ, B, Int, X} # X = γ*B = total dimension number
 end
 
-@inline MTDelayEmbedding(D, τ, B) = MTDelayEmbedding(Val{D}(), τ, Val{B}())
-@inline function MTDelayEmbedding(::Val{D}, τ::Int, ::Val{B}) where {D, B}
-    X = D*B
-    idxs = SMatrix{D,B,Int,X}([k*τ for k in 1:D, j in 1:B])
-    return MTDelayEmbedding{D, B, X}(idxs)
+@inline MTDelayEmbedding(γ, τ, B) = MTDelayEmbedding(Val{γ}(), τ, Val{B}())
+@inline function MTDelayEmbedding(::Val{γ}, τ::Int, ::Val{B}) where {γ, B}
+    X = γ*B
+    idxs = SMatrix{γ,B,Int,X}([k*τ for k in 1:γ, j in 1:B])
+    return MTDelayEmbedding{γ, B, X}(idxs)
 end
 @inline function MTDelayEmbedding(
-    ::Val{D}, τ::AbstractMatrix{<:Integer}, ::Val{B}) where {D, B}
-    X = D*B
-    D != size(τ)[1] && throw(ArgumentError(
+    ::Val{γ}, τ::AbstractMatrix{<:Integer}, ::Val{B}) where {γ, B}
+    X = γ*B
+    γ != size(τ)[1] && throw(ArgumentError(
     "`size(τ)[1]` must equal the number of spatial neighbors."
     ))
     B != size(τ)[2] && throw(ArgumentError(
     "`size(τ)[2]` must equal the number of timeseries."
     ))
-    return MTDelayEmbedding{D, B, X}(SMatrix{D, B, Int, X}(τ))
+    return MTDelayEmbedding{γ, B, X}(SMatrix{γ, B, Int, X}(τ))
 end
 function MTDelayEmbedding(
-    ::Val{D}, τ::AbstractVector{<:Integer}, ::Val{B}) where {D, B}
+    ::Val{γ}, τ::AbstractVector{<:Integer}, ::Val{B}) where {γ, B}
     error("Does not work with vector τ, only matrix or integer!")
 end
 
-@generated function (r::MTDelayEmbedding{D, B, X})(
+@generated function (r::MTDelayEmbedding{γ, B, X})(
     s::Union{AbstractDataset{B, T}, SizedArray{Tuple{A, B}, T, 2, M}},
-    i) where {D, A, B, T, M, X}
+    i) where {γ, A, B, T, M, X}
     gensprev = [:(s[i, $d]) for d=1:B]
-    gens = [:(s[i + r.delays[$k, $d], $d]) for k=1:D for d=1:B]
+    gens = [:(s[i + r.delays[$k, $d], $d]) for k=1:γ for d=1:B]
     quote
         @_inline_meta
-        @inbounds return SVector{$(D+1)*$B,T}($(gensprev...), $(gens...))
+        @inbounds return SVector{$(γ+1)*$B,T}($(gensprev...), $(gens...))
     end
 end
 
 @inline function reconstruct(
     s::Union{AbstractDataset{B, T}, SizedArray{Tuple{A, B}, T, 2, M}},
-    D, τ) where {A, B, T, M}
+    γ, τ) where {A, B, T, M}
 
-    de::MTDelayEmbedding{D, B, D*B} = MTDelayEmbedding(D, τ, B)
+    de::MTDelayEmbedding{γ, B, γ*B} = MTDelayEmbedding(γ, τ, B)
     reconstruct(s, de)
 end
 @inline function reconstruct(
     s::Union{AbstractDataset{B, T}, SizedArray{Tuple{A, B}, T, 2, M}},
-    de::MTDelayEmbedding{D, B, F}) where {A, B, T, M, D, F}
+    de::MTDelayEmbedding{γ, B, F}) where {A, B, T, M, γ, F}
 
     L = size(s)[1] - maximum(de.delays)
-    X = (D+1)*B
+    X = (γ+1)*B
     data = Vector{SVector{X, T}}(undef, L)
     @inbounds for i in 1:L
         data[i] = de(s, i)

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -1,6 +1,6 @@
 using StaticArrays
 using Base: @_inline_meta
-export reconstruct, DelayEmbedding, AbstractEmbedding, MTDelayEmbedding
+export reconstruct, DelayEmbedding, AbstractEmbedding, MTDelayEmbedding, embed
 
 #####################################################################################
 #                        Delay Embedding Reconstruction                             #
@@ -74,7 +74,7 @@ that the timeseries were recorded from, for proper `γ` and `τ` [1, 2].
 The case of different delay times allows reconstructing systems with many time scales,
 see [3].
 
-*Notice* - The dimension of the returned dataset is `γ+1`!
+*Notice* - The dimension of the returned dataset (i.e. embedding dimension) is `γ+1`!
 
 ### Multiple Timeseries
 To make a reconstruction out of a multiple timeseries (i.e. trajectory) the number
@@ -116,6 +116,17 @@ end
     end
     return Dataset{γ+1, T}(data)
 end
+
+"""
+    embed(s, D, τ)
+Perform a delay coordinates embedding on signal `s` with embedding dimension `D`
+and delay time `τ`.
+
+See [`reconstruct`](@ref) for an advanced version that supports multiple delay
+times and can reconstruct multiple timeseries efficiently.
+"""
+embed(s, D, τ) = reconstruct(s, D-1, τ)
+
 
 #####################################################################################
 #                              MultiDimensional R                                   #

--- a/test/neighborhood_tests.jl
+++ b/test/neighborhood_tests.jl
@@ -1,4 +1,4 @@
-using DelayEmbeddings
+using DelayEmbeddings, DynamicalSystemsBase
 using Test, StaticArrays
 
 println("\nTesting neighborhoods...")

--- a/test/reconstruction_tests.jl
+++ b/test/reconstruction_tests.jl
@@ -15,6 +15,7 @@ println("\nTesting reconstruct")
 
     		@test R[(1+τ):end, 1] == R[1:end-τ, 2]
     		@test size(R) == (length(s) - τ*D, D+1)
+            @test embed(s, D+1, τ) == R
     	end
     end
 


### PR DESCRIPTION
Closes #2

adds:
```
"""
    embed(s, D, τ)
Perform a delay coordinates embedding on signal `s` with embedding dimension `D`
and delay time `τ`.
See [`reconstruct`](@ref) for an advanced version that supports multiple delay
times and can reconstruct multiple timeseries efficiently.
"""
embed(s, D, τ) = reconstruct(s, D-1, τ)
```