### PR TITLE
New methods for estimating the embedding dimension

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.7.0-beta2
-Statistics
 StaticArrays 0.8
 Distances 0.7
 NearestNeighbors 0.4

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.7.0-beta2
+Statistics
 StaticArrays 0.8
 Distances 0.7
 NearestNeighbors 0.4

--- a/src/estimate_dimension.jl
+++ b/src/estimate_dimension.jl
@@ -1,9 +1,20 @@
-using NearestNeighbors
+using NearestNeighbors, Statistics
 
 export estimate_dimension, stochastic_indicator
 #####################################################################################
 #                                Estimate Dimension                                 #
 #####################################################################################
+
+# Function to increase the distance (p-norm) between two points `(i,j)` of
+# the embedded time `s`series, by adding one temporal neighbor
+function _increase_distance(δ::T, s::AbstractVector, i::Int, j::Int, γ::Int, τ::Int, p) where {T}
+    if p==Inf
+        return T( max(δ, abs(s[i+γ*τ+τ] - s[j+γ*τ+τ])) )
+    else
+        return T( (δ^p + abs(s[i+γ*τ+τ] - s[j+γ*τ+τ])^p )^(1/p) )
+    end
+end
+
 """
     estimate_dimension(s::AbstractVector, τ:Int, γs = 1:5) -> E₁s
 
@@ -25,12 +36,14 @@ find `γ` for which the value `E₁` saturates at some value around 1.
 
 [1] : Liangyue Cao, [Physica D, pp. 43-50 (1997)](https://www.sciencedirect.com/science/article/pii/S0167278997001188?via%3Dihub)
 """
-function estimate_dimension(s::AbstractVector{T}, τ::Int, γs = 1:5) where {T}
+estimate_dimension(s,γ,τ=1:5) = afnn(s,γ,τ,Inf) # By default it is `afnn` with Inf-norm
+
+function afnn(s::AbstractVector{T}, τ::Int, γs = 1:5, p=Inf) where {T}
     E1s = zeros(T, length(γs))
     aafter = zero(T)
-    aprev = _average_a(s, γs[1], τ)
+    aprev = _average_a(s, γs[1], τ, p)
     for (i, γ) ∈ enumerate(γs)
-        aafter = _average_a(s, γ+1, τ)
+        aafter = _average_a(s, γ+1, τ, p)
         E1s[i] = aafter/aprev
         aprev = aafter
     end
@@ -38,27 +51,26 @@ function estimate_dimension(s::AbstractVector{T}, τ::Int, γs = 1:5) where {T}
 end
 # then use function `saturation_point(γs, E1s)` from ChaosTools
 
-function _average_a(s::AbstractVector{T},γ,τ) where T
+function _average_a(s::AbstractVector{T},γ,τ,p) where T
     #Sum over all a(i,d) of the Ddim Reconstructed space, equation (2)
     R2 = reconstruct(s[1:end-τ],γ,τ)
     tree2 = KDTree(R2)
     nind = (x = knn(tree2, R2.data, 2)[1]; [ind[1] for ind in x])
     e=0.
-    for (i,j) in enumerate(nind)
-        δ = norm(R2[i]-R2[j], Inf)
+    for (i,j) ∈ enumerate(nind)
+        δ = norm(R2[i]-R2[j], p)
         #If R2[i] and R2[j] are still identical, choose the next nearest neighbor
         if δ == 0.
             j = knn(tree2, R2[i], 3, true)[1][end]
-            δ = norm(R2[i]-R2[j], Inf)
+            δ = norm(R2[i]-R2[j], p)
         end
-        δ1 = max(δ, abs(s[i+γ*τ+τ] - s[j+γ*τ+τ]))
-        e += δ1/δ
+        e += _increase_distance(δ,s,i,j,γ,τ,p)/δ
     end
     return e / (length(R2)-1)
 end
 
-function dimension_indicator(s,γ,τ) #this is E1, equation (3) of Cao
-    return _average_a(s,γ+1,τ)/_average_a(s,γ,τ)
+function dimension_indicator(s,γ,τ,p=Inf) #this is E1, equation (3) of Cao
+    return _average_a(s,γ+1,τ,p)/_average_a(s,γ,τ,p)
 end
 
 
@@ -108,3 +120,126 @@ function stochastic_indicator(s::AbstractVector{T},τ, γs=1:4) where T # E2, eq
     end
     return E2s
 end
+
+"""
+    fnn(s::AbstractVector, τ:Int, γs = 1:5, Rtol=10., Atol=2.)
+
+Calculate the number of "false nearest neighbors" (FNN) of the datasets created
+from `s` with a sequence of `τ`-delayed temporal neighbors.
+
+## Description
+Given a dataset made by embedding `s` with `γ` temporal neighbors and delay `τ`,
+the "false nearest neighbors" (FNN) are the pairs of points that are nearest to
+each other at dimension `γ`, but are separated at dimension `γ+1`. Kennel's
+criteria for detecting FNN are based on a threshold for the relative increment
+of the distance between the nearest neighbors (`Rtol`, eq. 4 in [1]), and
+another threshold for the ratio between the increased distance and the
+"size of the attractor" (`Atol`, eq. 5 in [1]).
+
+The returned value is a vector with the number of FNN for each `γ ∈ γs`. The
+optimal value for `γ` is found at the point where the number of FNN approaches
+zero.
+
+Please be aware that in **DynamicalSystems.jl** `γ` stands for the amount of temporal
+neighbors and not the embedding dimension (`D = γ + 1`, see also [`embed`](@ref)).
+
+See also: [`estimate_dimension](@ref), [`f1nn`](@ref).
+
+## References
+
+[1] : M. Kennel *et al.*, "Determining embedding dimension for phase-space
+reconstruction using a geometrical construction", *Phys. Review A 45*(6), 3403-3411
+(1992).
+"""
+function fnn(s::AbstractVector, τ::Int, γs = 1:5, Rtol=10., Atol=2.)
+    Rtol2 = Rtol^2
+    Ra = std(s, corrected=false)
+    nfnn = zeros(Int, length(γs))
+    for (k, γ) ∈ enumerate(γs)
+        y = reconstruct(s[1:end-τ],γ,τ)
+        tree = KDTree(y)
+        nind = (x = knn(tree, y.data, 2)[1]; [ind[1] for ind in x])
+        for (i,j) ∈ enumerate(nind)
+            δ = norm(y[i]-y[j], 2)
+            # If y[i] and y[j] are still identical, choose the next nearest neighbor
+            # as in Cao's algorithm (not suggested by Kennel, but still advisable)
+            if δ == 0.
+                j = knn(tree, y[i], 3, true)[1][end]
+                δ = norm(y[i]-y[j], 2)
+            end
+            δ1 = _increase_distance(δ,s,i,j,γ,τ,2)
+            cond_1 = ((δ1/δ)^2 - 1 > Rtol2) # equation (4) of Kennel
+            cond_2 = (δ1/Ra > Atol)         # equation (5) of Kennel
+            if cond_1 | cond_2
+                nfnn[k] += 1
+            end
+        end
+    end
+    return nfnn
+end
+
+"""
+    f1nn(s::AbstractVector, τ:Int, γs = 1:5, Rtol=10., Atol=2.)
+
+Calculate the ratio of "false first nearest neighbors" (FFNN) of the datasets created
+from `s` with a sequence of `τ`-delayed temporal neighbors.
+
+## Description
+Given a dataset made by embedding `s` with `γ` temporal neighbors and delay `τ`,
+the "first nearest neighbors" (FFNN) are the pairs of points that are nearest to
+each other at dimension `γ` that cease to be nearest neighbors at dimension
+`γ+1` [1].
+
+The returned value is a vector with the ratio between the number of FFNN and
+the number of points in the dataset for each `γ ∈ γs`. The optimal value for `γ`
+is found at the point where this ratio approaches zero.
+
+Please be aware that in **DynamicalSystems.jl** `γ` stands for the amount of temporal
+neighbors and not the embedding dimension (`D = γ + 1`, see also [`embed`](@ref)).
+
+See also: [`estimate_dimension](@ref), [`fnn`](@ref).
+
+## References
+
+[1] : Anna Krakovská *et al.*, "Use of false nearest neighbours for selecting
+variables and embedding parameters for state space reconstruction", *J Complex
+Sys* 932750 (2015), DOI: 10.1155/2015/932750
+"""
+function f1nn(s::AbstractVector, τ::Int, γs = 1:5)
+    f1nn_ratio = zeros(length(γs))
+    γ_prev = 0 # to recall what γ has been analyzed before
+    Rγ = reconstruct(s[1:end-τ],γs[1],τ) # this is for the first iteration 
+    for (i, γ) ∈ enumerate(γs)
+        if i>1 && γ!=γ_prev+1
+            # Re-calculate the series with γ delayed dims if γ does not follow
+            # the dimension of the previous iteration 
+            Rγ = reconstruct(s[1:end-τ],γ,τ)
+        end
+        (nf1nn, Rγ) = _compare_first_nn(s,γ,τ,Rγ)
+        f1nn_ratio[i] = nf1nn/length(Rγ)
+        # Trim Rγ for the next iteration
+        Rγ = Rγ[1:end-τ,:]
+        γ_prev = γ
+    end
+    return f1nn_ratio
+end
+
+function _compare_first_nn(s::AbstractVector{T},γ::Int,τ::Int,Rγ::Dataset{D,T}) where {D} where {T}
+    # This function compares the first nearest neighbors of `s`
+    # embedded with Dimensions `γ` and `γ+1` (the former given as input)
+    tree = KDTree(Rγ)
+    Rγ1 = reconstruct(s,γ+1,τ)
+    tree1 = KDTree(Rγ1)
+    nf1nn = 0
+    # For each point `i`, the fnn of `Rγ` is `j`, and the fnn of `Rγ1` is `k` 
+    nind = (x = knn(tree, Rγ.data, 2)[1]; [ind[1] for ind in x])
+    for  (i,j) ∈ enumerate(nind)
+        k = knn(tree1, Rγ1.data[i], 2, true)[1][end]
+        if j != k
+            nf1nn += 1
+        end
+    end
+    # `R1` is returned to re-use it if necessary
+    return (nf1nn, Rγ1)
+end
+

--- a/src/estimate_dimension.jl
+++ b/src/estimate_dimension.jl
@@ -40,7 +40,6 @@ end
 
 function _average_a(s::AbstractVector{T},γ,τ) where T
     #Sum over all a(i,d) of the Ddim Reconstructed space, equation (2)
-    R1 = reconstruct(s,γ+1,τ)
     R2 = reconstruct(s[1:end-τ],γ,τ)
     tree2 = KDTree(R2)
     nind = (x = knn(tree2, R2.data, 2)[1]; [ind[1] for ind in x])
@@ -52,9 +51,10 @@ function _average_a(s::AbstractVector{T},γ,τ) where T
             j = knn(tree2, R2[i], 3, true)[1][end]
             δ = norm(R2[i]-R2[j], Inf)
         end
-        e += norm(R1[i]-R1[j], Inf) / δ
+        δ1 = max(δ, abs(s[i+γ*τ+τ] - s[j+γ*τ+τ]))
+        e += δ1/δ
     end
-    return e / length(R1)
+    return e / (length(R2)-1)
 end
 
 function dimension_indicator(s,γ,τ) #this is E1, equation (3) of Cao

--- a/src/estimate_dimension.jl
+++ b/src/estimate_dimension.jl
@@ -16,7 +16,7 @@ function _increase_distance(δ::T, s::AbstractVector, i::Int, j::Int, γ::Int, �
 end
 
 """
-    estimate_dimension(s::AbstractVector, τ:Int, γs = 1:5, method = "afnn", p = Inf; kwargs...)
+    estimate_dimension(s::AbstractVector, τ::Int, γs = 1:5, method = "afnn"; kwargs...)
 
 Compute a quantity that can estimate an optimal amount of
 temporal neighbors `γ` to be used in [`reconstruct`](@ref) or [`embed`](@ref).
@@ -52,7 +52,7 @@ find `γ` for which the value `E₁` saturates at some value around 1.
 
 [1] : Liangyue Cao, [Physica D, pp. 43-50 (1997)](https://www.sciencedirect.com/science/article/pii/S0167278997001188?via%3Dihub)
 """
-function estimate_dimension(s::AbstractVector, τ:Int, γs = 1:5, method = "afnn"; kwargs...)
+function estimate_dimension(s::AbstractVector, τ::Int, γs = 1:5, method = "afnn"; kwargs...)
     if method == "afnn"
         return afnn(s, τ, γs)
     elseif method == "fnn"

--- a/src/estimate_dimension.jl
+++ b/src/estimate_dimension.jl
@@ -39,8 +39,8 @@ find `γ` for which the value `E₁` saturates at some value around 1.
 estimate_dimension(s,γ,τ=1:5) = afnn(s,γ,τ,Inf) # By default it is `afnn` with Inf-norm
 
 function afnn(s::AbstractVector{T}, τ::Int, γs = 1:5, p=Inf) where {T}
-    E1s = zeros(T, length(γs))
-    aafter = zero(T)
+    E1s = zeros(length(γs))
+    aafter = 0.0
     aprev = _average_a(s, γs[1], τ, p)
     for (i, γ) ∈ enumerate(γs)
         aafter = _average_a(s, γ+1, τ, p)
@@ -51,7 +51,7 @@ function afnn(s::AbstractVector{T}, τ::Int, γs = 1:5, p=Inf) where {T}
 end
 # then use function `saturation_point(γs, E1s)` from ChaosTools
 
-function _average_a(s::AbstractVector{T},γ,τ,p) where T
+function _average_a(s::AbstractVector{T},γ,τ,p) where {T}
     #Sum over all a(i,d) of the Ddim Reconstructed space, equation (2)
     R2 = reconstruct(s[1:end-τ],γ,τ)
     tree2 = KDTree(R2)
@@ -154,7 +154,7 @@ reconstruction using a geometrical construction", *Phys. Review A 45*(6), 3403-3
 function fnn(s::AbstractVector, τ::Int, γs = 1:5, Rtol=10., Atol=2.)
     Rtol2 = Rtol^2
     Ra = std(s, corrected=false)
-    nfnn = zeros(Int, length(γs))
+    nfnn = zeros(length(γs))
     for (k, γ) ∈ enumerate(γs)
         y = reconstruct(s[1:end-τ],γ,τ)
         tree = KDTree(y)

--- a/test/R_params.jl
+++ b/test/R_params.jl
@@ -60,31 +60,31 @@ end
 
 
 @testset "Estimate Dimension" begin
-    s = sin.(0:0.1:1000)
+    s_sin = sin.(0:0.1:1000)
     τ = 15
     Ds = 1:5
-    E1s = DelayEmbeddings.estimate_dimension(s, τ, Ds)
-    E2s = DelayEmbeddings.stochastic_indicator(s, τ, Ds)
+    E1s = DelayEmbeddings.estimate_dimension(s_sin, τ, Ds)
+    E2s = DelayEmbeddings.stochastic_indicator(s_sin, τ, Ds)
     @test saturation_point(Ds,E1s; threshold=0.01) == 1
 
     # @test minimum(E2s) < 0.1 # THIS TEST FAILS
 
     ds = Systems.roessler();τ=15; dt=0.1
     data = trajectory(ds,1000;dt=dt)
-    s = data[:,1]
+    s_roessler = data[:,1]
     Ds = 1:5
-    E1s = DelayEmbeddings.estimate_dimension(s, τ, Ds)
-    E2s = DelayEmbeddings.stochastic_indicator(s, τ, Ds)
+    E1s = DelayEmbeddings.estimate_dimension(s_roessler, τ, Ds)
+    E2s = DelayEmbeddings.stochastic_indicator(s_roessler, τ, Ds)
     @test saturation_point(Ds,E1s; threshold=0.1) ∈ [2, 3]
     @test minimum(E2s) < 0.3
 
 
     ds = Systems.lorenz();τ=5; dt=0.01
     data = trajectory(ds,500;dt=dt)
-    s = data[:,1]
+    s_lorenz = data[:,1]
     Ds = 1:5
-    E1s = DelayEmbeddings.estimate_dimension(s, τ, Ds)
-    E2s = DelayEmbeddings.stochastic_indicator(s, τ, Ds)
+    E1s = DelayEmbeddings.estimate_dimension(s_lorenz, τ, Ds)
+    E2s = DelayEmbeddings.stochastic_indicator(s_lorenz, τ, Ds)
     @test saturation_point(Ds,E1s; threshold=0.1) ∈ [2, 3]
 
     # @test minimum(E2s) < 0.1 # THIS TEST FAILS
@@ -92,5 +92,40 @@ end
     #Test against random signal
     E2s = DelayEmbeddings.stochastic_indicator(rand(100000), 1, 1:5)
     @test minimum(E2s) > 0.9
+    
+    
+    # Test `fnn` method
+    
+    τ = 15
+    Ds = 1:5
+    number_fnn = DelayEmbeddings.estimate_dimension(s_sin, τ, Ds, "fnn")
+    @test findfirst(number_fnn .≈ 0.0) == 1
+
+    τ = 15
+    Ds = 1:5
+    number_fnn = DelayEmbeddings.estimate_dimension(s_roessler, τ, Ds, "fnn"; Rtol=15)
+    @test findfirst(number_fnn .≈ 0.0) ∈ [2, 3]
+
+    τ = 1
+    Ds = 1:5
+    number_fnn = DelayEmbeddings.estimate_dimension(s_lorenz, τ, Ds, "fnn"; Atol=1, Rtol=3.0)
+    @test findfirst(number_fnn .≈ 0.0) ∈ [2, 3]
+    
+    # Test `f1nn` method
+    
+    τ = 15
+    Ds = 1:5
+    ffnn_ratio = DelayEmbeddings.estimate_dimension(s_sin, τ, Ds, "f1nn")
+    @test saturation_point(Ds,(1 .- ffnn_ratio); threshold=0.1) == 1
+
+    τ = 15
+    Ds = 1:5
+    ffnn_ratio = DelayEmbeddings.estimate_dimension(s_roessler, τ, Ds, "f1nn")
+    @test saturation_point(Ds,(1 .- ffnn_ratio); threshold=0.1) ∈ [2, 3]
+
+    τ = 15
+    Ds = 1:5
+    ffnn_ratio = DelayEmbeddings.estimate_dimension(s_lorenz, τ, Ds, "f1nn")
+    @test saturation_point(Ds,(1 .- ffnn_ratio); threshold=0.1) ∈ [2, 3]
 
 end

--- a/test/R_params.jl
+++ b/test/R_params.jl
@@ -92,10 +92,10 @@ end
     #Test against random signal
     E2s = DelayEmbeddings.stochastic_indicator(rand(100000), 1, 1:5)
     @test minimum(E2s) > 0.9
-    
-    
+
+
     # Test `fnn` method
-    
+
     τ = 15
     Ds = 1:5
     number_fnn = DelayEmbeddings.estimate_dimension(s_sin, τ, Ds, "fnn")
@@ -103,16 +103,16 @@ end
 
     τ = 15
     Ds = 1:5
-    number_fnn = DelayEmbeddings.estimate_dimension(s_roessler, τ, Ds, "fnn"; Rtol=15)
+    number_fnn = DelayEmbeddings.estimate_dimension(s_roessler, τ, Ds, "fnn"; atol=15)
     @test findfirst(number_fnn .≈ 0.0) ∈ [2, 3]
 
     τ = 1
     Ds = 1:5
-    number_fnn = DelayEmbeddings.estimate_dimension(s_lorenz, τ, Ds, "fnn"; Atol=1, Rtol=3.0)
+    number_fnn = DelayEmbeddings.estimate_dimension(s_lorenz, τ, Ds, "fnn"; atol=1, atol=3.0)
     @test findfirst(number_fnn .≈ 0.0) ∈ [2, 3]
-    
+
     # Test `f1nn` method
-    
+
     τ = 15
     Ds = 1:5
     ffnn_ratio = DelayEmbeddings.estimate_dimension(s_sin, τ, Ds, "f1nn")


### PR DESCRIPTION
This PR contains the following changes:

* d26e607 : improve performance of `_average_a` by not calculating `R1`, but updating the distance of the nearest neighbors of `R2` with the delayed values of the original time series.

* 3cb6fb0 : add other methods for estimating the optimal embedding dimension (Kennel's FNN -in `fnn` - and Krakovská's FFNN - in `f1nn`, I preferred using the `1` for "first" instead of yet another confusing `f`). The function `estimate_dimension` is renamed as `afnn` (standing for "average FNN"), although the original interface is kept by adding an alias with the older name.

I have modified `afnn` to accept yet another parameter - the index of the norm `p` for calculating distances, which defaults to `Inf` as in Cao's paper and the previous version of the function, but now can be changed to `2` if we want to use Euclidean distances (as in the other methods), etc.. This is combined with a new auxiliary function: `_increase_distance`, which is used to avoid calculating the embedded time series at `γ+1` (see previous commit), but works with different values of `p`.

* e5ce6c6 : just a revert of a silly change that I had made to REQUIRE.

The new version of Cao's method takes approx. 70% of the time it took before, and the other methods have approximately the same performance. None of the methods are exported in this PR, because I am not sure about what should be the interface. Options are:

*  Extend `estimate_dimension` with some optional parameter that lets you choose what method should be used. (In that case it may be advisable to revise the return types, since `fnn` returns an array of integers, whereas the other return an array of floats.)
* Keep `estimate_dimension` just as a legacy alias of `afnn`, and export the new methods.
* Some combination of the previous?