### PR TITLE
Allow `reconstruct` with γ=0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
 #     - 0.7
 julia:
   - 1.0
-  - nightly
+  # - nightly
 matrix:
   allow_failures:
   - julia: nightly

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
   - julia_version: 1
-  - julia_version: nightly
+  # - julia_version: nightly
 
 platform:
   - x86 # 32-bit

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -125,6 +125,9 @@ Dataset(x::Dataset) = x
 ###########################################################################
 # Dataset(Vectors of stuff)
 ###########################################################################
+Dataset{1, T}(s::AbstractVector{T}) where {T<:Number} =
+Dataset{1, T}(reinterpret(SVector{1, T}, s))
+
 function Dataset(v::Vector{<:AbstractArray{T}}) where {T<:Number}
     D = length(v[1])
     L = length(v)

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -106,20 +106,19 @@ Systems and Turbulence*, Lecture Notes in Mathematics **366**, Springer (1981)
 [3] : K. Judd & A. Mees, [Physica D **120**, pp 273 (1998)](https://www.sciencedirect.com/science/article/pii/S0167278997001188)
 """
 function reconstruct(s::AbstractVector{T}, γ, τ) where {T}
+    if γ == 0
+        return Dataset(s)
+    end
     de::DelayEmbedding{γ} = DelayEmbedding(Val{γ}(), τ)
     return reconstruct(s, de)
 end
 @inline function reconstruct(s::AbstractVector{T}, de::DelayEmbedding{γ}) where {T, γ}
-    if length(de.delays) == 0
-        return Dataset(s)
-    else
-        L = length(s) - maximum(de.delays)
-        data = Vector{SVector{γ+1, T}}(undef, L)
-        @inbounds for i in 1:L
-            data[i] = de(s, i)
-        end
-        return Dataset{γ+1, T}(data)
+    L = length(s) - maximum(de.delays)
+    data = Vector{SVector{γ+1, T}}(undef, L)
+    @inbounds for i in 1:L
+        data[i] = de(s, i)
     end
+    return Dataset{γ+1, T}(data)
 end
 
 """

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -107,7 +107,7 @@ Systems and Turbulence*, Lecture Notes in Mathematics **366**, Springer (1981)
 """
 function reconstruct(s::AbstractVector{T}, γ, τ) where {T}
     if γ == 0
-        return Dataset(s)
+        return Dataset{1, T}(s)
     end
     de::DelayEmbedding{γ} = DelayEmbedding(Val{γ}(), τ)
     return reconstruct(s, de)

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -191,6 +191,9 @@ end
     s::Union{AbstractDataset{B, T}, SizedArray{Tuple{A, B}, T, 2, M}},
     γ, τ) where {A, B, T, M}
 
+    if γ == 0
+        return Dataset{B, T}(s)
+    end
     de::MTDelayEmbedding{γ, B, γ*B} = MTDelayEmbedding(γ, τ, B)
     reconstruct(s, de)
 end
@@ -198,15 +201,11 @@ end
     s::Union{AbstractDataset{B, T}, SizedArray{Tuple{A, B}, T, 2, M}},
     de::MTDelayEmbedding{γ, B, F}) where {A, B, T, M, γ, F}
 
-    if length(de.delays) == 0
-        return Dataset(s)
-    else
-        L = size(s)[1] - maximum(de.delays)
-        X = (γ+1)*B
-        data = Vector{SVector{X, T}}(undef, L)
-        @inbounds for i in 1:L
-            data[i] = de(s, i)
-        end
-        return Dataset{X, T}(data)
+    L = size(s)[1] - maximum(de.delays)
+    X = (γ+1)*B
+    data = Vector{SVector{X, T}}(undef, L)
+    @inbounds for i in 1:L
+        data[i] = de(s, i)
     end
+    return Dataset{X, T}(data)
 end

--- a/test/R_params.jl
+++ b/test/R_params.jl
@@ -1,7 +1,7 @@
 using ChaosTools, DelayEmbeddings
 using Test
 
-println("\nTesting neighborhoods...")
+println("\nTesting R-param. estimation...")
 
 """
     saturation_point(x, y; threshold = 0.01, dxi::Int = 1, tol = 0.2)

--- a/test/reconstruction_tests.jl
+++ b/test/reconstruction_tests.jl
@@ -1,6 +1,6 @@
 using Test, StaticArrays, DelayEmbeddings
 
-println("\nTesting reconstruct")
+println("\nTesting reconstruct...")
 
 @testset "reconstruct" begin
 


### PR DESCRIPTION
Instead of tweaking the function `embed`, modify the `reconstruct` methods (and leave `embed` as originally).

This is convenient e.g. to include in the estimation of optimal dimensions the possibility of not doing any reconstruction at all.