### PR TITLE
Fixed bug in min_pairwise_distance and mutinfo

### DIFF
--- a/src/old_mutual_info.jl
+++ b/src/old_mutual_info.jl
@@ -45,7 +45,7 @@ function mutinfo(k, Xm::Vararg{<:AbstractVector,M}) where M
 
     I = digamma(k) - (M-1)/k + (M-1)*digamma(N)
 
-    nns = (x = knn(tree, d.data, k)[1]; [ind[1] for ind in x])
+    nns = (x = NearestNeighbors.knn(tree, d.data, k)[1]; [ind[1] for ind in x])
 
     I_itr = zeros(M)
     # Makes more sense computationally to loop over N rather than M

--- a/src/various.jl
+++ b/src/various.jl
@@ -19,7 +19,7 @@ function min_pairwise_distance(cts::AbstractMatrix)
     min_d = Inf
     min_pair = (0, 0)
     for p in 1:size(cts, 2)
-        inds, dists = knn(tree, view(cts, :, p), 1, false, i -> i == p)
+        inds, dists = NearestNeighbors.knn(tree, view(cts, :, p), 1, false, i -> i == p)
         ind, dist = inds[1], dists[1]
         if dist < min_d
             min_d = dist
@@ -37,7 +37,7 @@ function min_pairwise_distance(
     min_d = eltype(pts[1])(Inf)
     min_pair = (0, 0)
     for p in 1:length(pts)
-        inds, dists = knn(tree, pts[p], 1, false, i -> i == p)
+        inds, dists = NearestNeighbors.knn(tree, pts[p], 1, false, i -> i == p)
         ind, dist = inds[1], dists[1]
         if dist < min_d
             min_d = dist


### PR DESCRIPTION
The function `knn` from `NearestNeighbors` has also been imported from `Neighborhood` it has not been explicitly stated from which package `knn` was imported in `mutinfo` and `min_pairwise_distance`. Just changed that.