### PR TITLE
fixed sample bug

### DIFF
--- a/src/pecora.jl
+++ b/src/pecora.jl
@@ -225,7 +225,9 @@ function pecora(
     allts = columns(s)
     # indices of random fiducial points (with valid time range w.r.t. T)
     L = length(vspace)
-    ns = rand(max(1, (-minimum(delays) + 1)):min(L, L - maximum(delays)), N)
+    ns = sample(vec(max(1, (-minimum(delays) + 1)):min(L, L - maximum(delays))),
+    length(vec(max(1, (-minimum(delays) + 1)):min(L, L - maximum(delays)))),
+    replace = false)
     vs = vspace[ns]
     allNNidxs, allNNdist = all_neighbors(vtree, vs, ns, K, w)
     # prepare things for undersampling statistic

--- a/src/pecora.jl
+++ b/src/pecora.jl
@@ -225,9 +225,13 @@ function pecora(
     allts = columns(s)
     # indices of random fiducial points (with valid time range w.r.t. T)
     L = length(vspace)
-    ns = sample(vec(max(1, (-minimum(delays) + 1)):min(L, L - maximum(delays))),
-    length(vec(max(1, (-minimum(delays) + 1)):min(L, L - maximum(delays)))),
-    replace = false)
+    if samplesize==1
+        ns = vec(1:length(vec(max(1, (-minimum(delays) + 1)):min(L, L - maximum(delays)))))
+    else
+        ns = sample(vec(max(1, (-minimum(delays) + 1)):min(L, L - maximum(delays))),
+        length(vec(max(1, (-minimum(delays) + 1)):min(L, L - maximum(delays)))),
+        replace = false)
+    end
     vs = vspace[ns]
     allNNidxs, allNNdist = all_neighbors(vtree, vs, ns, K, w)
     # prepare things for undersampling statistic


### PR DESCRIPTION
I found a bug in `pecora` leading to non-consistent results. In the former version we took random samples with replacement. This does not make sense. We should never sample an index twice, this is no boot-strapping idea here. -Just a performance-implementation. Moreover, we took more samples than available numbers to choose from.
I fixed both problems using the `sample`-function from StatsBase.jl, which has been in the dependencies anyway. 
Now it gives consistent results.