### PR TITLE
bug-fixed epsilon-star-statistic; bug-fixed temporal range neighbors

### DIFF
--- a/src/pecora.jl
+++ b/src/pecora.jl
@@ -282,7 +282,7 @@ function continuity_per_timeseries(x::AbstractVector, ns, allNNidxs, delays, K, 
 end
 
 
-function ε★(x, n, τ, NNidxs, δ_to_ε_amount, Ks)
+function ε★(x, n, τ, NNidxs, δ_to_ε_amount::Dict, Ks::AbstractVector)
     a = x[n+τ] # fiducial point in ε-space
     @inbounds dis = [abs(a - x[i+τ]) for i in NNidxs]
     ε = zeros(length(Ks))


### PR DESCRIPTION
I discovered another bug, while comparing results of `pecora`, specifcally `continuity_per_timeseries`, to the results of my Matlab implementation. I fixed them in a few lines of code. Furthermore I shifted the computation of the dictionary for the δ-Neighborhood (calling `get_binomial_table`) from `ε★` into `continuity_per_timeseries`. This way it gets computed just once, instead of giving the same results, when calling `ε★` with the same parameters.