### PR TITLE
Horizontal concatenation of datasets, plus `Dataset` convenience constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.15.0
+* Horizontal concatenation of same-length `Vector{<:Real}` and `Dataset` in any order using 
+  `Base.hcat(x, y)` or `[x y]` syntax.
+* Convenience constructors that uses horizontal concatenation: 
+  `Dataset(::Dataset, ::Vector{<:Real})`, `Dataset(::Vector{<:Real}, ::Dataset)` and 
+  `Dataset(::Dataset, ::Dataset)`.
+
 # v1.14.0
 * New unified embedding method `pecuzal` by Kraemer et al.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayEmbeddings"
 uuid = "5732040d-69e3-5649-938a-b6b4f237613f"
 repo = "https://github.com/JuliaDynamics/DelayEmbeddings.jl.git"
-version = "1.14.4"
+version = "1.15.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -103,7 +103,7 @@ function Base.hcat(x::Vector{<:Real}, d::AbstractDataset{D, T}) where {D, T}
     L == length(x) || error("dataset and vector must be of same length")
     data = Vector{SVector{D+1, T}}(undef, L)
     @inbounds for i in 1:L
-        data[i] = SVector{D+1, T}(d[i]..., x[i])
+        data[i] = SVector{D+1, T}(x[i], d[i]...)
     end
     return Dataset(data)
 end

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -108,12 +108,13 @@ function Base.hcat(x::Vector{<:Real}, d::AbstractDataset{D, T}) where {D, T}
     return Dataset(data)
 end
 
-function hcat(x::AbstractDataset{D1, T}, y::AbstractDataset{D2, T}) where {D1, D2, T}
+function Base.hcat(x::AbstractDataset{D1, T}, y::AbstractDataset{D2, T}) where {D1, D2, T}
     length(x) == length(y) || error("Datasets must be of same length")
     L = length(x)
+    D = D1 + D2
     v = Vector{SVector{D, T}}(undef, L)
     for i = 1:L
-        v[i] = SVector{D1 + D2, T}((x[i]..., y[i]...,))
+        v[i] = SVector{D, T}((x[i]..., y[i]...,))
     end
     return Dataset(v)
 end
@@ -198,6 +199,12 @@ function Dataset(vecs::Vararg{<:AbstractVector{T}}) where {T}
     return Dataset(_dataset(vecs...))
 end
 
+
+# constructor that merges two datasets
+Dataset(x::AbstractDataset{D1, T}, y::AbstractDataset{D2, T}) where {D1, D2, T} = 
+    hcat(x, y)
+Dataset(x::Vector{<:Real}, y::AbstractDataset{D, T}) where {D, T} = hcat(x, y)
+Dataset(x::AbstractDataset{D, T}, y::Vector{<:Real}) where {D, T} = hcat(x, y)
 
 #####################################################################################
 #                                Dataset <-> Matrix                                 #

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -98,6 +98,26 @@ function Base.hcat(d::AbstractDataset{D, T}, x::Vector{<:Real}) where {D, T}
     return Dataset(data)
 end
 
+function Base.hcat(x::Vector{<:Real}, d::AbstractDataset{D, T}) where {D, T}
+    L = length(d)
+    L == length(x) || error("dataset and vector must be of same length")
+    data = Vector{SVector{D+1, T}}(undef, L)
+    @inbounds for i in 1:L
+        data[i] = SVector{D+1, T}(d[i]..., x[i])
+    end
+    return Dataset(data)
+end
+
+function hcat(x::AbstractDataset{D1, T}, y::AbstractDataset{D2, T}) where {D1, D2, T}
+    length(x) == length(y) || error("Datasets must be of same length")
+    L = length(x)
+    v = Vector{SVector{D, T}}(undef, L)
+    for i = 1:L
+        v[i] = SVector{D1 + D2, T}((x[i]..., y[i]...,))
+    end
+    return Dataset(v)
+end
+
 ###########################################################################
 # Concrete implementation
 ###########################################################################

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -199,8 +199,6 @@ function Dataset(vecs::Vararg{<:AbstractVector{T}}) where {T}
     return Dataset(_dataset(vecs...))
 end
 
-
-# constructor that merges two datasets
 Dataset(x::AbstractDataset{D1, T}, y::AbstractDataset{D2, T}) where {D1, D2, T} = 
     hcat(x, y)
 Dataset(x::Vector{<:Real}, y::AbstractDataset{D, T}) where {D, T} = hcat(x, y)

--- a/test/dataset_tests.jl
+++ b/test/dataset_tests.jl
@@ -6,6 +6,14 @@ println("\nTesting Dataset...")
 @testset "Dataset" begin
   data = Dataset(rand(1001,3))
   xs = columns(data)
+
+  @testset "Concatenation" begin 
+    x, y, z = Dataset(rand(10, 2)), Dataset(rand(10, 2)), rand(10)
+    @test Dataset(x, y) isa Dataset
+    @test Dataset(x, z) isa Dataset
+    @test Dataset(z, x) isa Dataset
+  end
+
   @testset "Methods & Indexing" begin
     a = data[:, 1]
     b = data[:, 2]


### PR DESCRIPTION
I often find myself wanting to horizontally concatenate datasets with datasets, datasets with a real-valued vector, or a real-valued vector with a dataset. 

Instead of having to redefine `Base.hcat(x::Dataset, y::Dataset)`, `Base.hcat(x::Vector{<:Real}, y::Dataset)`, and `Base.hcat(x::Dataset, y::Vector{<:Real})`, as well as `Dataset(x::Dataset, y::Dataset)`, `Dataset(x::Vector{<:Real}, y::Dataset)` and `Dataset(x::Dataset, y::Vector{<:Real})`, to achieve this, it would be nice to have this as part of DelayEmbeddings. 

This PR implements precisely that, and adds some tests. 