### PR TITLE
Allow weights in generalized embeddings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,18 @@ jobs:
       matrix:
         version:
           - '1'
-        os:  [ubuntu-latest]
+        os:  [ubuntu-latest] # adjust according to need, e.g. os: [ubuntu-latest] if testing only on linux
         arch:
           - x64
     steps:
+      # Cancel ongoing CI test runs if pushing to branch again before the previous tests
+      # have finished
+      - name: Cancel ongoing test runs for previous commits
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+
+      # Do tests
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
+# v1.16.0
+* Arbitrary weights can be given as options to `genembed`.
+
 # v1.15.0
-* Horizontal concatenation of same-length `Vector{<:Real}` and `Dataset` in any order using 
+* Horizontal concatenation of same-length `Vector{<:Real}` and `Dataset` in any order using
   `Base.hcat(x, y)` or `[x y]` syntax.
-* Convenience constructors that uses horizontal concatenation: 
-  `Dataset(::Dataset, ::Vector{<:Real})`, `Dataset(::Vector{<:Real}, ::Dataset)` and 
+* Convenience constructors that uses horizontal concatenation:
+  `Dataset(::Dataset, ::Vector{<:Real})`, `Dataset(::Vector{<:Real}, ::Dataset)` and
   `Dataset(::Dataset, ::Dataset)`.
 
 # v1.14.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayEmbeddings"
 uuid = "5732040d-69e3-5649-938a-b6b4f237613f"
 repo = "https://github.com/JuliaDynamics/DelayEmbeddings.jl.git"
-version = "1.15.0"
+version = "1.16.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/src/embeddings.jl
+++ b/src/embeddings.jl
@@ -277,18 +277,12 @@ function Base.show(io::IO, g::GeneralizedEmbedding{D}) where {D}
     print(io, "  js: $(g.js)")
 end
 
-# timeseries input
-@generated function (g::GeneralizedEmbedding{D})(s::AbstractArray{T}, i::Int) where {D, T}
-    gens = [:(s[i + g.τs[$k]]) for k=1:D]
-    quote
-        @_inline_meta
-        @inbounds return SVector{$D,T}($(gens...))
-    end
-end
-
-# dataset input
 @generated function (g::GeneralizedEmbedding{D})(s::Dataset{X, T}, i::Int) where {D, X, T}
-    gens = [:(s[i + g.τs[$k], g.js[$k]]) for k=1:D]
+    if s isa Dataset
+        gens = [:(s[i + g.τs[$k], g.js[$k]]) for k=1:D]
+    elseif s isa AbstractVector
+        gens = [:(s[i + g.τs[$k]]) for k=1:D]
+    end
     quote
         @_inline_meta
         @inbounds return SVector{$D,T}($(gens...))

--- a/test/embedding_tests.jl
+++ b/test/embedding_tests.jl
@@ -55,9 +55,9 @@ println("\nTesting generalized embedding...")
     τs = (0, 2, -7)
     js = (1, 3, 2)
     ge = GeneralizedEmbedding(τs, js)
+    τr = τrange(s, ge)
     @testset "univariate" begin
         x = rand(20)
-        τr = τrange(x, ge)
         em = genembed(x, τs, js)
         @test em == genembed(x, τs)
         @test em[1:3, 3] == x[1:3]
@@ -66,11 +66,18 @@ println("\nTesting generalized embedding...")
     end
     @testset "multivariate" begin
         s = Dataset(rand(20, 3))
-        τr = τrange(s, ge)
         em = genembed(s, τs, js)
         x, y, z = columns(s)
         @test em[1:3, 1] == x[1+7:3+7]
-        @test em[1:3, 3] == y[1:3]
         @test em[1:3, 2] == z[1+7+2:3+7+2]
+        @test em[1:3, 3] == y[1:3]
     end
+    @testset "weighted" begin
+        s = Dataset(rand(20, 3))
+        x, y, z = columns(s)
+        ws = (1, 0, 0.1)
+        em = genembed(s, τs, js; ws)
+        @test em[1:3, 1] == x[1+7:3+7]
+        @test em[1:3, 2] == 0 .* z[1+7+2:3+7+2]
+        @test em[1:3, 3] == 0.1 .* y[1:3]
 end

--- a/test/embedding_tests.jl
+++ b/test/embedding_tests.jl
@@ -80,4 +80,5 @@ println("\nTesting generalized embedding...")
         @test em[1:3, 1] == x[1+7:3+7]
         @test em[1:3, 2] == 0 .* z[1+7+2:3+7+2]
         @test em[1:3, 3] == 0.1 .* y[1:3]
+    end
 end

--- a/test/embedding_tests.jl
+++ b/test/embedding_tests.jl
@@ -1,4 +1,4 @@
-using Test, StaticArrays, DelayEmbeddings
+using Test, DelayEmbeddings
 
 println("\nTesting delay embeddings...")
 
@@ -78,5 +78,14 @@ println("\nTesting generalized embedding...")
         @test em[1:3, 1] == x[1+7:3+7]
         @test em[1:3, 2] == 0 .* z[1+7+2:3+7+2]
         @test em[1:3, 3] == 0.1 .* y[1:3]
+    end
+    @testset "weighted integer" begin
+        ws = (1, 0, -0.1)
+        x = collect(1:100)
+        ge = GeneralizedEmbedding(τs, js, ws)
+        em = genembed(x, τs, js; ws)
+        @test em[1:3, 1] == x[1+7:3+7]
+        @test em[1:3, 2] == 0 .* x[1+7+2:3+7+2]
+        @test em[1:3, 3] == -0.1 .* x[1:3]
     end
 end

--- a/test/embedding_tests.jl
+++ b/test/embedding_tests.jl
@@ -55,26 +55,24 @@ println("\nTesting generalized embedding...")
     τs = (0, 2, -7)
     js = (1, 3, 2)
     ge = GeneralizedEmbedding(τs, js)
+    s = Dataset(rand(20, 3))
+    x, y, z = columns(s)
     τr = τrange(s, ge)
     @testset "univariate" begin
-        x = rand(20)
-        em = genembed(x, τs, js)
-        @test em == genembed(x, τs)
-        @test em[1:3, 3] == x[1:3]
-        @test em[1:3, 1] == x[1+7:3+7]
-        @test em[1:3, 2] == x[1+7+2:3+7+2]
+        w = rand(20)
+        em = genembed(w, τs, js)
+        @test em == genembed(w, τs)
+        @test em[1:3, 3] == w[1:3]
+        @test em[1:3, 1] == w[1+7:3+7]
+        @test em[1:3, 2] == w[1+7+2:3+7+2]
     end
     @testset "multivariate" begin
-        s = Dataset(rand(20, 3))
         em = genembed(s, τs, js)
-        x, y, z = columns(s)
         @test em[1:3, 1] == x[1+7:3+7]
         @test em[1:3, 2] == z[1+7+2:3+7+2]
         @test em[1:3, 3] == y[1:3]
     end
     @testset "weighted" begin
-        s = Dataset(rand(20, 3))
-        x, y, z = columns(s)
         ws = (1, 0, 0.1)
         em = genembed(s, τs, js; ws)
         @test em[1:3, 1] == x[1+7:3+7]


### PR DESCRIPTION
Allows each entry of a `genembed` to be further multiplied by a provided weight `w`. (optional, by default is off)