### PR TITLE
Weights docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayEmbeddings"
 uuid = "5732040d-69e3-5649-938a-b6b4f237613f"
 repo = "https://github.com/JuliaDynamics/DelayEmbeddings.jl.git"
-version = "1.16.0"
+version = "1.16.1"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/src/embeddings.jl
+++ b/src/embeddings.jl
@@ -330,8 +330,8 @@ The generalized embedding works as follows:
   `τs` is allowed to have *negative entries* as well.
 - `js` denotes which of the timeseries contained in `s`
   will be used for the entries of the delay vector. `js` can contain duplicate indices.
-- `ws` are optional weights that weight each embedded entry.
-  If provided, it is recommeded that `ws[1] = 1`
+- `ws` are optional weights that weight each embedded entry (the i-th entry of the 
+    delay vector is weighted by `ws[i]`). If provided, it is recommended that `ws[1] = 1`
 
 `τs, js, ws` are tuples (or vectors) of length `D`, which also coincides with the embedding
 dimension. For example, imagine input trajectory ``s = [x, y, z]`` where ``x, y, z`` are


### PR DESCRIPTION
Sorry, I should have paid more attention! I missed a typo in PR #67. 

Also, I added a small clarification to the docstring about the weights, because it was a bit unclear to me what the `ws` argument is supposed to do reading the docstrings the first few times (I had to experiment with `genembed` to understand what the `ws` argument did). I think it is a bit more clear now. However, if you feel it's better the way it is, I can remove the additional explanation it. 