### PR TITLE
Move all code to Neighborhood.jl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.17.0
+* All code related to neighborhoods and finding nearest neighbors has moved to Neighborhood.jl, and thus old names like `FixedMassNeighborhood` and `neighborhood` have been deprecated.
+
 # v1.16.0
 * Arbitrary weights can be given as options to `genembed`.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayEmbeddings"
 uuid = "5732040d-69e3-5649-938a-b6b4f237613f"
 repo = "https://github.com/JuliaDynamics/DelayEmbeddings.jl.git"
-version = "1.16.1"
+version = "1.17.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -126,6 +126,8 @@ end
     Dataset{D, T} <: AbstractDataset{D,T}
 A dedicated interface for datasets.
 It contains *equally-sized datapoints* of length `D`, represented by `SVector{D, T}`.
+These data are contained in the field `.data` of a dataset, as a standard Julia
+`Vector{SVector}`.
 
 When indexed with 1 index, a `dataset` is like a vector of datapoints.
 When indexed with 2 indices it behaves like a matrix that has each of the columns be the
@@ -199,7 +201,7 @@ function Dataset(vecs::Vararg{<:AbstractVector{T}}) where {T}
     return Dataset(_dataset(vecs...))
 end
 
-Dataset(x::AbstractDataset{D1, T}, y::AbstractDataset{D2, T}) where {D1, D2, T} = 
+Dataset(x::AbstractDataset{D1, T}, y::AbstractDataset{D2, T}) where {D1, D2, T} =
     hcat(x, y)
 Dataset(x::Vector{<:Real}, y::AbstractDataset{D, T}) where {D, T} = hcat(x, y)
 Dataset(x::AbstractDataset{D, T}, y::Vector{<:Real}) where {D, T} = hcat(x, y)

--- a/src/neighborhoods.jl
+++ b/src/neighborhoods.jl
@@ -3,14 +3,12 @@
 #####################################################################################
 using Neighborhood, Distances
 
-export search, WithinRange, NeighborNumber, bulksearch, bulkisearch, Theiler, KDTree
+export WithinRange, NeighborNumber, Theiler, KDTree
 export Euclidean, Chebyshev
 
 Neighborhood.KDTree(D::AbstractDataset, metric::Metric = Euclidean(); kwargs...) =
 KDTree(D.data, metric; kwargs...)
 
-# TODO: Function returns 0-indices and -Inf values, when w is too high compared
-#       to the length of vtree. This should be fixed, i.e. throw an error
 """
     all_neighbors(vtree, vs, ns, K, w)
 Return the `maximum(K)`-th nearest neighbors for all input points `vs`,
@@ -19,6 +17,7 @@ with indices `ns` in original data, while respecting the theiler window `w`.
 This function is nothing more than a convinience call to `Neighborhood.bulksearch`.
 """
 function all_neighbors(vtree, vs, ns, K, w)
+    w ≥ length(vtree.data)-1 && error("Theiler window larger than the entire data span!")
     k = maximum(K)
     tw = Theiler(w, ns)
     idxs, dists = bulksearch(vtree, vs, NeighborNumber(k), tw)

--- a/src/neighborhoods.jl
+++ b/src/neighborhoods.jl
@@ -3,11 +3,19 @@
 #####################################################################################
 using Neighborhood, Distances
 
-export WithinRange, NeighborNumber, Theiler, KDTree
-export Euclidean, Chebyshev
+export WithinRange, NeighborNumber
+export Euclidean, Chebyshev, Cityblock
 
 Neighborhood.KDTree(D::AbstractDataset, metric::Metric = Euclidean(); kwargs...) =
 KDTree(D.data, metric; kwargs...)
+
+# Convenience extensions for ::Dataset in bulksearches
+for f ∈ (:bulkisearch, :bulksearch)
+    for nt ∈ (:NeighborNumber, :WithinRange)
+        @eval Neighborhood.$(f)(ss::KDTree, D::Dataset, st::$nt, args...; kwargs...) =
+        $(f)(ss, D.data, st, args...; kwargs...)
+    end
+end
 
 """
     all_neighbors(vtree, vs, ns, K, w)

--- a/src/neighborhoods.jl
+++ b/src/neighborhoods.jl
@@ -1,3 +1,31 @@
+#####################################################################################
+#                   Neighborhood.jl Interface & convenience functions               #
+#####################################################################################
+using Neighborhood, Distances
+
+export search, WithinRange, NeighborNumber, bulksearch, bulkisearch, Theiler, KDTree
+export Euclidean, Chebyshev
+
+KDTree(D::AbstractDataset, metric::Metric = Euclidean()) = KDTree(D.data, metric)
+
+# TODO: Function returns 0-indices and -Inf values, when w is too high compared
+#       to the length of vtree. This should be fixed, i.e. throw an error
+"""
+    all_neighbors(vtree, vs, ns, K, w)
+Return the `maximum(K)`-th nearest neighbors for all input points `vs`,
+with indices `ns` in original data, while respecting the theiler window `w`.
+
+This function is nothing more than a convinience call to `Neighborhood.bulksearch`.
+"""
+function all_neighbors(vtree, vs, ns, K, w)
+    k = maximum(K)
+    tw = Theiler(w, ns)
+    idxs, dists = bulksearch(vtree, vs, NeighborNumber(k), tw)
+end
+
+#####################################################################################
+#                Old Neighborhood Interface, deprecated                             #
+#####################################################################################
 using NearestNeighbors, StaticArrays
 using Distances: Euclidean, Metric
 import NearestNeighbors: KDTree
@@ -6,9 +34,6 @@ export AbstractNeighborhood
 export FixedMassNeighborhood, FixedSizeNeighborhood
 export neighborhood, KDTree
 
-#####################################################################################
-#                              Neighborhoods n stuff                                #
-#####################################################################################
 """
     AbstractNeighborhood
 Supertype of methods for deciding the neighborhood of points for a given point.
@@ -34,6 +59,11 @@ struct FixedSizeNeighborhood <: AbstractNeighborhood
     ε::Float64
 end
 FixedSizeNeighborhood() = FixedSizeNeighborhood(0.01)
+
+@deprecate AbstractNeighborhood SearchType
+@deprecate FixedSizeNeighborhood WithinRange
+@deprecate FixedMassNeighborhood NeighborNumber
+@deprecate neighborhood search
 
 """
     neighborhood(point, tree, ntype)
@@ -78,25 +108,17 @@ function neighborhood(point::AbstractVector, tree, ntype::FixedSizeNeighborhood)
     return idxs
 end
 
-KDTree(D::AbstractDataset, metric::Metric = Euclidean()) = KDTree(D.data, metric)
 
 
 # TODO: This must use the new Neighborhood.jl
-# TODO: Function returns 0-indices and -Inf values, when w is too high compared
-#       to the length of vtree. This should be fixed, i.e. throw an error
-"""
-    all_neighbors(vtree, vs, ns, K, w)
-Return the `maximum(K)`-th nearest neighbors for all input points `vs`, with indices `ns` in
-original data, while respecting the theiler window `w`.
-"""
-function all_neighbors(vtree, vs, ns, K, w)
-    k, sortres, N = maximum(K), true, length(vs)
-    dists = [Vector{eltype(vs[1])}(undef, k) for _ in 1:N]
-    idxs = [Vector{Int}(undef, k) for _ in 1:N]
-    for i in 1:N
-        # The skip predicate also skips the point itself for w ≥ 0
-        skip = j -> ns[i] - w ≤ j ≤ ns[i] + w
-        NearestNeighbors.knn_point!(vtree, vs[i], sortres, dists[i], idxs[i], skip)
-    end
-    return idxs, dists
-end
+# function all_neighbors(vtree, vs, ns, K, w)
+#     k, sortres, N = maximum(K), true, length(vs)
+#     dists = [Vector{eltype(vs[1])}(undef, k) for _ in 1:N]
+#     idxs = [Vector{Int}(undef, k) for _ in 1:N]
+#     for i in 1:N
+#         # The skip predicate also skips the point itself for w ≥ 0
+#         skip = j -> ns[i] - w ≤ j ≤ ns[i] + w
+#         NearestNeighbors.knn_point!(vtree, vs[i], sortres, dists[i], idxs[i], skip)
+#     end
+#     return idxs, dists
+# end

--- a/src/traditional_de/estimate_dimension.jl
+++ b/src/traditional_de/estimate_dimension.jl
@@ -255,9 +255,12 @@ function _compare_first_nn(s, γ::Int, τ::Int, Rγ::Dataset{D,T}, metric) where
     tree1 = KDTree(Rγ1,metric)
     nf1nn = 0
     # For each point `i`, the fnn of `Rγ` is `j`, and the fnn of `Rγ1` is `k`
-    nind = (x = NearestNeighbors.knn(tree, Rγ.data, 2)[1]; [ind[1] for ind in x])
-    @inbounds for  (i,j) ∈ enumerate(nind)
-        k = NearestNeighbors.knn(tree1, Rγ1.data[i], 2, true)[1][end]
+    _nind = bulkisearch(tree, Rγ.data, NeighborNumber(1), Theiler(0))
+    nind = (x[1] for x in _nind) # bulksearch always returns vectors of vectors
+    # nind = (x = NearestNeighbors.knn(tree, Rγ.data, 2)[1]; [ind[1] for ind in x])
+    @inbounds for (i,j) ∈ enumerate(nind)
+        # k = NearestNeighbors.knn(tree1, Rγ1.data[i], 2, true)[1][end]
+        k = Neighborhood.knn(tree1, Rγ1.data[i], 1, Theiler(0)(i))[1][1]
         if j != k
             nf1nn += 1
         end

--- a/src/traditional_de/estimate_dimension.jl
+++ b/src/traditional_de/estimate_dimension.jl
@@ -105,10 +105,9 @@ function stochastic_indicator(s::AbstractVector{T}, τ, ds) where T # E2, equati
     for d ∈ ds
         Rγ1 = embed(s,d+1,τ)
         tree1 = KDTree(Rγ1[1:end-1-τ])
-        method = FixedMassNeighborhood(2)
-
         Es1 = 0.0
-        nind = (x = neighborhood(Rγ1[1:end-τ], tree1, method); [ind[1] for ind in x])
+        _nind = bulkisearch(tree1, Rγ1[1:end-τ], NeighborNumber(1), Theiler(0))
+        nind = (x[1] for x in _nind) # bulksearch always returns vectors of vectors
         for  (i,j) ∈ enumerate(nind)
             Es1 += abs(Rγ1[i+τ][end] - Rγ1[j+τ][end]) / length(Rγ1)
         end
@@ -117,7 +116,8 @@ function stochastic_indicator(s::AbstractVector{T}, τ, ds) where T # E2, equati
         Rγ = embed(s,d,τ)
         tree2 = KDTree(Rγ[1:end-1-τ])
         Es2 = 0.0
-        nind = (x = neighborhood(Rγ[1:end-τ], tree2, method); [ind[1] for ind in x])
+        _nind = bulkisearch(tree2, Rγ[1:end-τ], NeighborNumber(1), Theiler(0))
+        nind = (x[1] for x in _nind)
         for  (i,j) ∈ enumerate(nind)
             Es2 += abs(Rγ[i+τ][end] - Rγ[j+τ][end]) / length(Rγ)
         end

--- a/test/embedding_dimension_test.jl
+++ b/test/embedding_dimension_test.jl
@@ -2,7 +2,7 @@ using DelayEmbeddings
 using Test
 using DynamicalSystemsBase
 
-println("\nTesting delay count estimation...")
+println("\nTesting traditional optimal embedding dimension...")
 test_value = (val, vmin, vmax) -> @test vmin <= val <= vmax
 
 @testset "Embedding dimension estimation" begin


### PR DESCRIPTION
Remove using `NearestNeighbors` directly in favor of using `Neighborhood`, which also provides a robust interface for the Theiler window.