### PR TITLE
deprecate mutualinformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.18.0
+* `mutualinformation` is deprecated in favor of `selfmutualinfo`.
+
 # v1.17.0
 * All code related to neighborhoods and finding nearest neighbors has moved to Neighborhood.jl, and thus old names like `FixedMassNeighborhood` and `neighborhood` have been deprecated.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayEmbeddings"
 uuid = "5732040d-69e3-5649-938a-b6b4f237613f"
 repo = "https://github.com/JuliaDynamics/DelayEmbeddings.jl.git"
-version = "1.17.0"
+version = "1.18.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/src/DelayEmbeddings.jl
+++ b/src/DelayEmbeddings.jl
@@ -19,4 +19,6 @@ include("unified_de/MDOP.jl")
 include("unified_de/garcia_almeida.jl")
 include("unified_de/pecuzal.jl")
 
+include("deprecate.jl")
+
 end

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -1,0 +1,5 @@
+export mutualinformation
+function mutualinformation(args...; kwargs...)
+    @warn "`mutualinformation` is deprecated in favor of `selfmutualinfo`."
+    selfmutualinfo(args...; kwargs...)
+end

--- a/src/traditional_de/estimate_delay.jl
+++ b/src/traditional_de/estimate_delay.jl
@@ -14,7 +14,7 @@ The `method` can be one of the following:
 * `"ac_min"` : delay of first minimum of the auto-correlation function.
 * `"mi_min"` : delay of first minimum of mutual information of `s` with itself
   (shifted for various `τs`).
-  Keywords `nbins, binwidth` are propagated into [`mutualinformation`](@ref).
+  Keywords `nbins, binwidth` are propagated into [`selfmutualinfo`](@ref).
 * `"exp_decay"` : [`exponential_decay_fit`](@ref) of the correlation function rounded
    to an integer (uses least squares on `c(t) = exp(-t/τ)` to find `τ`).
 * `"exp_extrema"` : same as above but the exponential fit is done to the
@@ -47,7 +47,7 @@ function estimate_delay(x::AbstractVector, method::String,
         c = autocor(x, τs, demean=true)
         return mincrossing(c, τs)
     elseif method=="mi_min"
-        c = mutualinformation(x, τs; kwargs...)
+        c = selfmutualinfo(x, τs; kwargs...)
         return mincrossing(c, τs)
     elseif method=="exp_decay"
         c = autocor(x, τs; demean=true)
@@ -119,11 +119,16 @@ end
 #####################################################################################
 #                               Mutual information                                  #
 #####################################################################################
-export mutualinformation
-"""
-    mutualinformation(s, τs[; nbins, binwidth])
+export selfmutualinfo, mutualinformation
+function mutualinformation(args...; kwargs...)
+    @warn "`mutualinformation` is deprecated in favor of `selfmutualinfo`."
+    selfmutualinfo(args...; kwargs...)
+end
 
-Calculate the mutual information between the time series `s` and its images
+"""
+    selfmutualinfo(s, τs; kwargs...) → m
+
+Calculate the mutual information between the time series `s` and itself
 delayed by `τ` points for `τ` ∈ `τs`, using an _improvement_ of the method
 outlined by Fraser & Swinney in[^Fraser1986].
 
@@ -132,7 +137,7 @@ outlined by Fraser & Swinney in[^Fraser1986].
 The joint space of `s` and its `τ`-delayed image (`sτ`) is partitioned as a
 rectangular grid, and the mutual information is computed from the joint and
 marginal frequencies of `s` and `sτ` in the grid as defined in [1].
-The mutual information values are returned in a vector of the same length
+The mutual information values are returned in a vector `m` of the same length
 as `τs`.
 
 If any of the optional keyword parameters is given, the grid will be a
@@ -155,7 +160,7 @@ frequencies of `s`.
 
 [^Fraser1986]: Fraser A.M. & Swinney H.L. "Independent coordinates for strange attractors from mutual information" *Phys. Rev. A 33*(2), 1986, 1134:1140.
 """
-function mutualinformation(s::AbstractVector{T}, τs::AbstractVector{Int};
+function selfmutualinfo(s::AbstractVector{T}, τs::AbstractVector{Int};
     kwargs...) where {T}
     n = length(s)
     nτ = n-maximum(τs)

--- a/src/traditional_de/estimate_delay.jl
+++ b/src/traditional_de/estimate_delay.jl
@@ -119,11 +119,7 @@ end
 #####################################################################################
 #                               Mutual information                                  #
 #####################################################################################
-export selfmutualinfo, mutualinformation
-function mutualinformation(args...; kwargs...)
-    @warn "`mutualinformation` is deprecated in favor of `selfmutualinfo`."
-    selfmutualinfo(args...; kwargs...)
-end
+export selfmutualinfo
 
 """
     selfmutualinfo(s, τs; kwargs...) → m

--- a/src/traditional_de/estimate_delay.jl
+++ b/src/traditional_de/estimate_delay.jl
@@ -172,14 +172,14 @@ function selfmutualinfo(s::AbstractVector{T}, τs::AbstractVector{Int};
     mi_values = zeros(length(τs))
     for (i, τ) ∈ enumerate(τs)
         sτ = view(s, τ+1:n)[perm] # delayed and reordered time series
-        mi_values[i] = _mutualinfo!(f, sτ, bins, edges)
+        mi_values[i] = _selfmutualinfo!(f, sτ, bins, edges)
     end
     return mi_values
 end
 
 
 """
-    _mutualinfo!(f, sτ, edges, bins0)
+    _selfmutualinfo!(f, sτ, edges, bins0)
 
 Calculate the mutual information between the distribution of the delayed time
 series `sτ` and its original image.
@@ -193,7 +193,7 @@ are contained in the following `bins[2]` positions, etc.
 
 The vector `f` is used as a placeholder to pre-allocate the histogram.
 """
-function _mutualinfo!(f::AbstractVector, sτ::AbstractVector,
+function _selfmutualinfo!(f::AbstractVector, sτ::AbstractVector,
     bins0::AbstractVector{<:Integer}, edges::AbstractVector)
 
     # Initialize values

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using DelayEmbeddings
 using StaticArrays
 
 # Download some test timeseries
-repo = "https://raw.githubusercontent.com/JuliaDynamics/ExercisesRepo/master/timeseries"
+repo = "https://raw.githubusercontent.com/JuliaDynamics/ExercisesRepo/master/exercise_data"
 tsfolder = joinpath(@__DIR__, "timeseries")
 todownload = ["$n.csv" for n in 1:4]
 


### PR DESCRIPTION
This PR deprecates the name `mutualinformation` because it will result to both conflict and confusion. For a long time I've been wanting to add a proper mutual information method `mutualinfo(x, y; ...)` in one of the packages of JuliaDynamics.

This function missleads with its name, because it only works for _self_ - mutual information, and I don't see a straightforward way to extend it to new arguments.

The new function `mutualinfo` will serve this purpose. At the moment we are discussing whether this function should go into Entropies.jl or TransferEntropy.jl.