### PR TITLE
added option for different return type for orthonormal function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.2.0
+* added option for different return type for orthonormal function, returns now SMatrix only for small matrices, otherwise Matrix
+
 # v2.0.0
 **BREAKING**
 - All deprecations have been removed and errors will be thrown now instead. Switch to previous stable version to enable them again.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayEmbeddings"
 uuid = "5732040d-69e3-5649-938a-b6b4f237613f"
 repo = "https://github.com/JuliaDynamics/DelayEmbeddings.jl.git"
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -109,7 +109,7 @@ Return a matrix `ws` with `k` columns, each being
 an `D`-dimensional orthonormal vector.
 `T` is the return type and can be either `SMatrix` or `Matrix`
 
-returns either SMatrix{D, k} if D*k < 100, otherwise Matrix{D, k}
+returns either SMatrix{D, k} if D*k < 100, otherwise Dxk Matrix{Float64}
 """
 function orthonormal end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -108,7 +108,7 @@ end
 Return a matrix `ws` with `k` columns, each being
 an `D`-dimensional orthonormal vector.
 
-Default: returns SMatrix{D, k} if D*k < 100, otherwise Matrix
+returns either SMatrix{D, k} if D*k < 100, otherwise Matrix{D, k}
 """
 function orthonormal end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -104,19 +104,25 @@ function to_vectorSvector(a::AbstractMatrix)
 end
 
 """
-    orthonormal(D, k) -> ws
+    orthonormal([T,] D, k) -> ws
 Return a matrix `ws` with `k` columns, each being
 an `D`-dimensional orthonormal vector.
 
-Always return `SMatrix` for stability reasons.
+Default: returns SMatrix{D, k} if D*k < 100, otherwise Matrix
 """
 function orthonormal end
 
-@inline function orthonormal(D::Int, k::Int)
-    k > D && throw(ArgumentError("k must be ≤ D"))
-    q = qr(rand(SMatrix{D, k})).Q
-end
+orthonormal(D, k) = D*k < 100 ? orthonormal(SMatrix, D, k) : orthonormal(Matrix, D, k)
 
+@inline function orthonormal(T::Type, D::Int, k::Int)
+    k > D && throw(ArgumentError("k must be ≤ D"))
+    if T == SMatrix
+        q = qr(rand(SMatrix{D, k})).Q
+    elseif T == Matrix
+        q = Matrix(qr(rand(Float64, D, k)).Q)
+    end
+    q
+end
 
 """
     hcat_lagged_values(Y, s::Vector, τ::Int) -> Z

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -107,6 +107,7 @@ end
     orthonormal([T,] D, k) -> ws
 Return a matrix `ws` with `k` columns, each being
 an `D`-dimensional orthonormal vector.
+`T` is the return type and can be either `SMatrix` or `Matrix`
 
 returns either SMatrix{D, k} if D*k < 100, otherwise Matrix{D, k}
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ diffeq = (atol = 1e-9, rtol = 1e-9, maxiters = typemax(Int))
 @testset "DelayEmbeddings tests" begin
     include("dataset_tests.jl")
     include("embedding_tests.jl")
-    include("utils_tests.jl")
+    include("utils_test.jl")
     include("traditional/delaytime_test.jl")
     include("traditional/embedding_dimension_test.jl")
     include("unified/test_pecora.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ diffeq = (atol = 1e-9, rtol = 1e-9, maxiters = typemax(Int))
 @testset "DelayEmbeddings tests" begin
     include("dataset_tests.jl")
     include("embedding_tests.jl")
+    include("utils_tests.jl")
     include("traditional/delaytime_test.jl")
     include("traditional/embedding_dimension_test.jl")
     include("unified/test_pecora.jl")

--- a/test/utils_test.jl
+++ b/test/utils_test.jl
@@ -1,0 +1,10 @@
+using Test, DelayEmbeddings
+
+println("\nTesting utils...")
+
+@testset "utils" begin
+
+    A = orthonormal(50, 50)
+    @test size(A) == (50, 50)
+
+end

--- a/test/utils_test.jl
+++ b/test/utils_test.jl
@@ -6,5 +6,8 @@ println("\nTesting utils...")
 
     A = orthonormal(50, 50)
     @test size(A) == (50, 50)
+    @test A isa Matrix
 
+    B = orthonormal(3, 3)
+    @test B isa SMatrix
 end


### PR DESCRIPTION
I think this code is not very pretty, I haven't seriously coded in `julia` in a while, so feel free to tell me what I could/ should do better. But I think it works at least. 
This would solve #106 