### PR TITLE
Adjust to JuliaDynamics/StateSpaceSets.jl#39

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayEmbeddings"
 uuid = "5732040d-69e3-5649-938a-b6b4f237613f"
 repo = "https://github.com/JuliaDynamics/DelayEmbeddings.jl.git"
-version = "2.8.0"
+version = "2.9.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
@@ -19,6 +19,6 @@ Distances = "0.10"
 Distributions = "0.25"
 Neighborhood = "0.2"
 Reexport = "1"
-StateSpaceSets = "2"
+StateSpaceSets = "2.4"
 StatsBase = "0.24, 0.32, 0.33, 0.34"
 julia = "1.5"

--- a/src/embeddings/genembed.jl
+++ b/src/embeddings/genembed.jl
@@ -124,7 +124,7 @@ end
 
 function genembed(s, ge::GeneralizedEmbedding{D, W}) where {D, W}
     r = τrange(s, ge)
-    T = eltype(s)
+    T = eltype(eltype(s))
     X = W == Nothing ? T : promote_type(T, W)
     data = Vector{SVector{D, X}}(undef, length(r))
     @inbounds for (i, n) in enumerate(r)


### PR DESCRIPTION
Adjust for the changes in [JuliaDynamics/StateSpaceSets.jl#39](https://github.com/JuliaDynamics/StateSpaceSets.jl/issues/39) I.e. retrieve the element type of the stored point, instead of the element type of the StateSpaceSet

See [JuliaDynamics/Associations.jl#398](https://github.com/JuliaDynamics/Associations.jl/issues/398)